### PR TITLE
Corrected Linting and Case Statements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -104,12 +104,13 @@ define macfirewall ($action = 'string', $value = 'string') {
             unless    => "${gatekeeper} --status | ${grep} --master-${value}",
           } # end exec
         } # end gatekeeper
-
-        default:
+        default: {
           fail('The action used is not defined. Please use a defined action.')
+        }
       } # end case $action
     } # end case $::operatingsystem
-    default:
+    default: {
       fail('The macfirewall can only be used on macOS.')
+    }
   } # end case Darwin
 } # end define

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,8 +19,8 @@ define macfirewall ($action = 'string', $value = 'string') {
 
   # Works only on Darwin
   if $facts['os']['name'] != 'Darwin' {
-    fail('The macbluetooth resource type is only supported on macOS')
- }
+    fail('The macfirewall resource type is only supported on macOS')
+  }
 
   # Commands for interpolation / shorthand
   $cmd = '/usr/libexec/ApplicationFirewall/socketfilterfw'
@@ -35,77 +35,81 @@ define macfirewall ($action = 'string', $value = 'string') {
 
         'add': {
           exec { "${cmd} --add ${value}":
-            command       => "${cmd} --add ${value}",
-            logoutput     => true,
-            unless        => "${cmd} --listapps | ${grep} ${value}",
+            command   => "${cmd} --add ${value}",
+            logoutput => true,
+            unless    => "${cmd} --listapps | ${grep} ${value}",
           } # end exec
         } # end add
 
         'block': {
           exec { "${cmd} --blockapp ${value}":
-            command       => "${cmd} --blockapp ${value}",
-            logoutput     => true,
-            onlyif        => "${cmd} --listapps | ${grep} ${value}",
+            command   => "${cmd} --blockapp ${value}",
+            logoutput => true,
+            onlyif    => "${cmd} --listapps | ${grep} ${value}",
           } # end exec
         } # end block
 
         'remove': {
           exec { "${cmd} --remove ${value}":
-            command       => "${cmd} --remove ${value}",
-            logoutput     => true,
-            onlyif        => "${cmd} --listapps | ${grep} ${value}",
+            command   => "${cmd} --remove ${value}",
+            logoutput => true,
+            onlyif    => "${cmd} --listapps | ${grep} ${value}",
           } # end exec
         } # End remove
 
         'stealth': {
           exec { "${cmd} --setstealthmode ${value}":
-            command       => "${cmd} --setstealthmode ${value}",
-            logoutput     => true,
-            unless        => "${cmd} --getstealthmode | ${grep} ${value}",
+            command   => "${cmd} --setstealthmode ${value}",
+            logoutput => true,
+            unless    => "${cmd} --getstealthmode | ${grep} ${value}",
           } # end exec
         } # end stealth
 
         'globalstate': {
           exec { "${cmd} --setglobalstate ${value}":
-            command       => "${cmd} --setglobalstate ${value}",
-            logoutput     => true,
-            unless        => "${cmd} --getglobalstate | ${grep} ${value}",
+            command   => "${cmd} --setglobalstate ${value}",
+            logoutput => true,
+            unless    => "${cmd} --getglobalstate | ${grep} ${value}",
           } # end exec
         } # end globalstate
 
         'logging': {
           exec { "${cmd} --setloggingmode ${value}":
-            command       => "${cmd} --setloggingmode ${value}",
-            logoutput     => true,
-            unless        => "${cmd} --getloggingmode | ${grep} ${value}",
+            command   => "${cmd} --setloggingmode ${value}",
+            logoutput => true,
+            unless    => "${cmd} --getloggingmode | ${grep} ${value}",
           } # end exec
         } # end logging
 
         'signed': {
           exec { "${cmd} --setallowsigned ${value}":
-            command       => "${cmd} --setallowsigned ${value}",
-            logoutput     => true,
-            unless        => "${cmd} --getallowsigned | ${grep} ${value}",
+            command   => "${cmd} --setallowsigned ${value}",
+            logoutput => true,
+            unless    => "${cmd} --getallowsigned | ${grep} ${value}",
           } # end exec
         } # end signed
 
         'signedapps': {
           exec { "${cmd} --setallowsignedapp ${value}":
-            command       => "${cmd} --setallowsignedapp ${value}",
-            logoutput     => true,
-            unless        => "${cmd} --getallowsigned | ${grep} ${value}",
+            command   => "${cmd} --setallowsignedapp ${value}",
+            logoutput => true,
+            unless    => "${cmd} --getallowsigned | ${grep} ${value}",
           } # end exec
         } # end signedapps
 
         'gatekeeper': {
           exec { "${gatekeeper} --master-${value}":
-            command       => "${gatekeeper} --master-${value}",
-            logoutput     => true,
-            unless        => "${gatekeeper} --status | ${grep} --master-${value}",
+            command   => "${gatekeeper} --master-${value}",
+            logoutput => true,
+            unless    => "${gatekeeper} --status | ${grep} --master-${value}",
           } # end exec
         } # end gatekeeper
 
+        default:
+          fail('The action used is not defined. Please use a defined action.')
       } # end case $action
     } # end case $::operatingsystem
+    default:
+      fail('The macfirewall can only be used on macOS.')
   } # end case Darwin
 } # end define


### PR DESCRIPTION
The => items were to far left in alignment. There were no default case statements for the action and ::operatingsystem cases. Also corrected typo in initial fail case that made reference to a bluetooth module.